### PR TITLE
Update default implementation for alterRequest

### DIFF
--- a/src/Plugin/Purl/Method/PathPrefixMethod.php
+++ b/src/Plugin/Purl/Method/PathPrefixMethod.php
@@ -24,11 +24,23 @@ class PathPrefixMethod extends MethodAbstract implements MethodInterface, Reques
         return strpos($path, '/' . $modifier) === 0;
     }
 
+   /**
+    * Allow for altering the request when the RequestSubscriber event fires.
+    *
+    * @param \Symfony\Component\HttpFoundation\Request $request
+    * @param $identifier
+    *
+    * @return \Symfony\Component\HttpFoundation\Request
+    * Return the request or FALSE if the request was not altered.
+    *
+    */
     public function alterRequest(Request $request, $identifier)
     {
         $uri = $request->server->get('REQUEST_URI');
         $newPath = substr($uri, strlen($identifier) + 1);
         $request->server->set('REQUEST_URI', $newPath);
+
+        return $request;
     }
 
     public function enterContext($modifier, $path, array &$options)

--- a/src/Plugin/Purl/Method/RequestAlteringInterface.php
+++ b/src/Plugin/Purl/Method/RequestAlteringInterface.php
@@ -16,5 +16,15 @@ use Symfony\Component\HttpFoundation\Request;
  */
 interface RequestAlteringInterface
 {
-    public function alterRequest(Request $request, $identifier);
+  /**
+   * Allow for altering the request when the RequestSubscriber event fires.
+   *
+   * @param \Symfony\Component\HttpFoundation\Request $request
+   * @param $identifier
+   *
+   * @return \Symfony\Component\HttpFoundation\Request
+   * Return the request or FALSE if the request was not altered.
+   *
+   */
+  public function alterRequest(Request $request, $identifier);
 }


### PR DESCRIPTION
This adds the return value for alterRequest to provide a template for request altering methods and to fix the default implementation.

Note: Group Purl has the same issue and I am submitting a separate patch here: https://www.drupal.org/project/group_purl/issues/3058009