### PR TITLE
Revert "404 value is stored in cache after software release is created."

### DIFF
--- a/src/Routing/PurlRouteProvider.php
+++ b/src/Routing/PurlRouteProvider.php
@@ -163,9 +163,7 @@ class PurlRouteProvider extends RouteProvider {
         'query' => $query_parameters,
         'routes' => $routes,
       ];
-      if ($routes->getResources()) {
-        $this->cache->set($cid, $cache_value, CacheBackendInterface::CACHE_PERMANENT, ['route_match']);
-      }
+      $this->cache->set($cid, $cache_value, CacheBackendInterface::CACHE_PERMANENT, ['route_match']);
       return $routes;
     }
   }


### PR DESCRIPTION
Reverts openscholar/purl-d8#9

This is no longer needed. https://github.com/openscholar/openscholar/issues/13043#issuecomment-619759497