### PR TITLE
Omit the need to call all modifiers.

### DIFF
--- a/src/Event/RequestSubscriber.php
+++ b/src/Event/RequestSubscriber.php
@@ -4,7 +4,6 @@ namespace Drupal\purl\Event;
 
 use Drupal\purl\Entity\Provider;
 use Drupal\purl\MatchedModifiers;
-use Drupal\purl\Modifier;
 use Drupal\purl\Plugin\MethodPluginManager;
 use Drupal\purl\Plugin\ModifierIndex;
 use Drupal\purl\Plugin\ProviderManager;
@@ -20,12 +19,6 @@ use Symfony\Component\HttpKernel\KernelEvents;
 
 class RequestSubscriber implements EventSubscriberInterface
 {
-
-  /**
-   * Group purl provider id.
-   */
-  const GROUP_PURL_PROVIDER = 'group_purl_provider';
-
   /**
    * @var ModifierIndex
    */
@@ -69,31 +62,10 @@ class RequestSubscriber implements EventSubscriberInterface
   public function onRequest(GetResponseEvent $event, $eventName, EventDispatcherInterface $dispatcher)
   {
     $request = $event->getRequest();
-    $uri = $request->getPathInfo();
-    [, $uri] = explode('/', $uri);
-
-    // Eliminate the need to get and iterate through all the modifiers as it is
-    // a very resource intensive process.
-    $provider = Provider::load(self::GROUP_PURL_PROVIDER);
-    if ($provider) {
-      $provider_plugin = $this->provider->getProviderPlugin();
-    }
-    if ($provider_plugin) {
-      $modifier = $provider_plugin->getModifierDataByKey($uri);
-      // If this key is not a modifier then it means that either this is
-      // any other sitewide page or this a sub request within a vsite and a
-      // modifier was matched already in the previous request.
-      if (empty($modifier)) {
-        return;
-      }
-      $modifiers[] = new Modifier(key($modifier), reset($modifier), $provider->getMethodPlugin(), $provider);
-    }
-    // If no group purl provider is present then proceed as normal.
-    else {
-      $modifiers = $this->getModifiers();
-    }
+    $modifiers = $this->getModifiers();
 
     $matches = array();
+
     foreach ($modifiers as $modifier) {
 
       $provider = $modifier->getProvider();

--- a/src/Plugin/ModifierIndex.php
+++ b/src/Plugin/ModifierIndex.php
@@ -41,7 +41,7 @@ class ModifierIndex
   {
     $modifiers = [];
 
-    if (method_exists($provider->getProviderPlugin(), 'getModifierDataByValue')) {
+    if (method_exists($provider->getProviderPlugin(), 'getModifierDataByKey')) {
       foreach ($provider->getProviderPlugin()->getModifierDataByKey($key) as $k => $value) {
         $modifiers[] = new Modifier($k, $value, $provider->getMethodPlugin(), $provider);
       }


### PR DESCRIPTION
https://github.com/openscholar/openscholar/issues/14405

I thought it would be better if we can totally omit the need to call all the modifiers rather them calling them all once and caching (that would still mean that every time cache is invalidated we need to query the DB multiple times), when we know that modifier is to be matched from the uri, why not use the URI to get the modifier and just match that rather than getting all modifiers by querying the DB (as many times as is the vsite count on the install) and then matching them one by one.

This does need some changes in `group purl module` too for which I am in process of creating patches and also am testing out certain aspects and fixing some notices being thrown. (This did need some thought and trying out multiple things to get everything working as before, but for this PR more or less this should be final code.)

Raising this PR so that this can be reviewed till then and potential side effects can be assessed which can impact currently or in future.
@rbran100 @Bilsi @jashish24 