### PR TITLE
fix last() with end()

### DIFF
--- a/src/Event/RequestSubscriber.php
+++ b/src/Event/RequestSubscriber.php
@@ -108,7 +108,7 @@ class RequestSubscriber implements EventSubscriberInterface
       $previous_modifiers = $this->matchedModifiers->getMatched();
       if (count($previous_modifiers)) {
         /** @var ModifierMatchedEvent $previous */
-        $previous = last($previous_modifiers);
+        $previous = end($previous_modifiers);
         if ($previous->getProvider() == $match['provider_key']
           && $previous->getModifier() == $match['modifier']
           && $previous->getValue() == $match['value']


### PR DESCRIPTION
last() isn't a PHP function, using end() seems to work

tested against group_purl